### PR TITLE
Rework image storage scheme

### DIFF
--- a/nrtk_explorer/app/transforms.py
+++ b/nrtk_explorer/app/transforms.py
@@ -141,9 +141,7 @@ class TransformsApp(Applet):
 
             transformed_image_ids.append(transformed_image_id)
 
-            self.state[transformed_image_id] = self.context.images_manager.ComputeBase64(
-                transformed_image_id, transformed_img
-            )
+            self.state[transformed_image_id] = images_manager.convert_to_base64(transformed_img)
             self.state[transformed_meta_id] = self.state[meta_id]
 
             self.state.hovered_id = -1
@@ -184,9 +182,9 @@ class TransformsApp(Applet):
 
             image_filename = os.path.join(current_dir, image_metadata["file_name"])
 
-            img = self.context.images_manager.LoadImage(image_filename)
+            img = self.context.images_manager.load_thumbnail(image_filename)
 
-            self.state[image_id] = self.context.images_manager.ComputeBase64(image_id, img)
+            self.state[image_id] = images_manager.convert_to_base64(img)
             self.state[meta_id] = {
                 "width": image_metadata["width"],
                 "height": image_metadata["height"],

--- a/nrtk_explorer/library/embeddings_extractor.py
+++ b/nrtk_explorer/library/embeddings_extractor.py
@@ -70,7 +70,7 @@ class EmbeddingsExtractor:
             if content and path in content:
                 img = content[path]
             else:
-                img = self.manager.LoadImage(path)
+                img = self.manager.load_image_for_model(path)
 
             transformed_images.append(self.transform_image(img))
 

--- a/nrtk_explorer/library/images_manager.py
+++ b/nrtk_explorer/library/images_manager.py
@@ -4,29 +4,51 @@ from PIL import Image as ImageModule
 import base64
 import io
 
+# Resolution for images to be used in model
+IMAGE_MODEL_RESOLUTION = (224, 224)
+THUMBNAIL_RESOLUTION = (250, 250)
 
-def image_to_base64_str(img: Image, format: str) -> str:
+
+def convert_to_base64(img: Image) -> str:
+    """Convert image to base64 string"""
     buf = io.BytesIO()
-    img.save(buf, format=format)
-    return f"data:image/{format};base64," + base64.b64encode(buf.getvalue()).decode()
+    img.save(buf, format="png")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
 class ImagesManager:
-    def __init__(self, server_context=None):
-        if server_context:
-            server_context["images_cache"] = {}
-            self.images = server_context["images_cache"]
-        else:
-            self.images = {}
+    """Class to manage images and thumbnails"""
 
-    def LoadImage(self, path):
+    def __init__(self):
+        self.images = {}
+        self.thumbnails = {}
+        self.images_for_model = {}
+
+    def prepare_for_model(self, img):
+        """Prepare image for model input"""
+        img = img.resize(IMAGE_MODEL_RESOLUTION)
+        return img.convert("RGB")
+
+    def load_image(self, path):
+        """Load image from path and store it in cache if not already loaded"""
         if path not in self.images:
-            img = ImageModule.open(path)
-            img = img.resize((224, 224))
-            img = img.convert("RGB")
-            self.images[path] = img
+            self.images[path] = ImageModule.open(path)
 
         return self.images[path]
 
-    def ComputeBase64(self, img_id, img):
-        return image_to_base64_str(img, "png")
+    def load_image_for_model(self, path):
+        """Load image for model from path and store it in cache if not already loaded"""
+        if path not in self.images_for_model:
+            img = self.load_thumbnail(path)
+            self.images_for_model[path] = self.prepare_for_model(img)
+
+        return self.images_for_model[path]
+
+    def load_thumbnail(self, path):
+        """Load thumbnail from path and store it in cache if not already loaded"""
+        if path not in self.thumbnails:
+            img = self.load_image(path)
+            img.thumbnail(THUMBNAIL_RESOLUTION)
+            self.thumbnails[path] = img
+
+        return self.thumbnails[path]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -125,7 +125,7 @@ def test_features_extractor_benchmark(image_paths):
     # Pre-load images
     manager = images_manager.ImagesManager()
     for path in image_paths[: max(sampling)]:
-        manager.LoadImage(path)
+        manager.load_image_for_model(path)
 
     for n, batch_size in setups:
         extractor = embeddings_extractor.EmbeddingsExtractor(manager=manager)


### PR DESCRIPTION
In this PR I add several things:

- I extracted the bits from #41 to make sure that we work with visdrone dataset (fixed image id selection).
- I reworked how we resize images and the different type of images that we save, I change the schema of image types and sizes that we store as shown in the diagram below.
- I heavily refactored image_manager module.
- ~I added the commit from #43 to fix reactivity so we can have all the changes in one go.~

```mermaid
graph TD;
    OriginalImage-->Thumbnail;
    OriginalImage--->OriginalTransformation;
    Thumbnail-->ImageForModel;
    Thumbnail-->ThumbnailTransformation;
    ThumbnailTransformation-->TransformationForModel;
```