### PR TITLE
Image list fixes: Bounding boxes image missmatch, Unknown annotation category

### DIFF
--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -157,9 +157,9 @@ class TransformsApp(Applet):
         for id_ in ids:
             self.context["annotations"][id_] = []
 
-        prediction = self.detector.eval(paths=ids, content=self.context.image_objects)
+        predictions = self.detector.eval(paths=ids, content=self.context.image_objects)
 
-        for id_, annotations in zip(ids, prediction):
+        for id_, annotations in predictions:
             image_annotations = self.context["annotations"].setdefault(id_, [])
             for prediction in annotations:
                 category_id = 0

--- a/vue-components/src/components/ImageDetection.vue
+++ b/vue-components/src/components/ImageDetection.vue
@@ -230,8 +230,8 @@ function mouseMove(e: MouseEvent) {
       const item = document.createElement('li')
       if (hit.data != undefined) {
         const annotation = props.annotations[hit.data]
-        const category = props.categories[annotation.category_id]
-        item.textContent = `(${annotation.id}): ${category.name}`
+        const { name } = props.categories[annotation.category_id] ?? { name: 'Unknown' }
+        item.textContent = `(${annotation.id}): ${name}`
         const color = CATEGORY_COLORS[annotation.category_id % CATEGORY_COLORS.length]
         item.style.textShadow = `rgba(${color.join(',')},0.6) 1px 1px 3px`
         list.appendChild(item)


### PR DESCRIPTION
* When selecting a set of images, some of which share the same image shape, the bouding boxes could be on the wrong image.
* The horse drawn trolly thing in the sample dataset has a category ID of 0, which caused a JS error.  Not sure about root cause...
![image](https://github.com/Kitware/nrtk-explorer/assets/16823231/7f1e1759-8163-4d79-86f4-9b15558ee24f)
