### PR TITLE
ci: create_release only in release branch

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,49 +1,11 @@
 name: Create Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - release
 
 jobs:
-  push_to_release:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - name: Configure git user
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "github-actions"
-
-      - name: Sync git branches
-        run: |
-          git fetch
-          git checkout main
-          git pull
-          git checkout release
-          git pull
-
-      - name: History main
-        run: |
-          git log main
-
-      - name: History release
-        run: |
-          git log release
-
-      - name: Merge main to release
-        run: |
-          git merge --no-ff main -m "Merge main to release"
-          git push
   release:
     needs: push_to_release
     runs-on: ubuntu-latest
@@ -59,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: release
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/push_to_release.yaml
+++ b/.github/workflows/push_to_release.yaml
@@ -1,0 +1,43 @@
+name: Push to release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push_to_release:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+
+      - name: Sync git branches
+        run: |
+          git fetch
+          git checkout main
+          git pull
+          git checkout release
+          git pull
+
+      - name: History main
+        run: |
+          git log main
+
+      - name: History release
+        run: |
+          git log release
+
+      - name: Merge main to release
+        run: |
+          git merge --no-ff main -m "Merge main to release"
+          git push


### PR DESCRIPTION
We need this since sometimes such as at #65 we only wanted to backport a few fixed, however, our current prepare_to_release will bring every main commit to release anyways.