### PR TITLE
ci: add nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-- push
-- pull_request
+  push:
+  pull_request:
+  schedule:
+  - cron: "0 10 * * *"
 
 jobs:
   linters_python:


### PR DESCRIPTION
We need this to make sure that we do not lose compatibility with the newer versions of our dependencies. 