### PR TITLE
conda: add conda env that includes cuda pytorch

### DIFF
--- a/examples/conda-env-cuda.yml
+++ b/examples/conda-env-cuda.yml
@@ -1,0 +1,13 @@
+name: nrtk-explorer-cuda
+channels:
+  - nvidia
+  - pytorch
+  - conda-forge
+dependencies:
+  - pytorch::pytorch
+  - pytorch::torchvision
+  - pytorch::torchaudio
+  - pytorch::pytorch-cuda=11.8
+  - nrtk-explorer
+variables:
+    channel_priority: flexible


### PR DESCRIPTION
Adds an example conda env file that install nrtk-explorer with cuda