### PR TITLE
Fix type checks when missing libraries

### DIFF
--- a/src/nrtk_explorer/library/nrtk_transforms.py
+++ b/src/nrtk_explorer/library/nrtk_transforms.py
@@ -15,9 +15,13 @@ try:
     from pybsm.otf import darkCurrentFromDensity
     from nrtk.impls.perturb_image.generic.cv2.blur import GaussianBlurPerturber
     from nrtk.impls.perturb_image.pybsm.perturber import PybsmPerturber, PybsmSensor, PybsmScenario
+    GaussianBlurPerturberType = Union[GaussianBlurPerturber, None]
+    PybsmPerturberType = Union[PybsmPerturber, None]
 except ImportError:
     logger.info("Disabling NRTK transforms due to missing library/failing imports")
     ENABLED_NRTK_TRANSFORMS = False
+    GaussianBlurPerturberType = None
+    PybsmPerturberType = None
 
 
 def nrtk_transforms_available():
@@ -25,7 +29,7 @@ def nrtk_transforms_available():
 
 
 class NrtkGaussianBlurTransform(ImageTransform):
-    def __init__(self, perturber: Union[GaussianBlurPerturber, None] = None):
+    def __init__(self, perturber: GaussianBlurPerturberType = None):
         if perturber is None:
             perturber = GaussianBlurPerturber()
 
@@ -155,7 +159,7 @@ def createSampleSensorAndScenario():
 
 
 class NrtkPybsmTransform(ImageTransform):
-    def __init__(self, perturber: Union[PybsmPerturber, None] = None):
+    def __init__(self, perturber: PybsmPerturberType = None):
         if perturber is None:
             sensor, scenario = createSampleSensorAndScenario()
             perturber = PybsmPerturber(sensor=sensor, scenario=scenario)

--- a/src/nrtk_explorer/library/nrtk_transforms.py
+++ b/src/nrtk_explorer/library/nrtk_transforms.py
@@ -15,6 +15,7 @@ try:
     from pybsm.otf import darkCurrentFromDensity
     from nrtk.impls.perturb_image.generic.cv2.blur import GaussianBlurPerturber
     from nrtk.impls.perturb_image.pybsm.perturber import PybsmPerturber, PybsmSensor, PybsmScenario
+
     GaussianBlurPerturberType = Union[GaussianBlurPerturber, None]
     PybsmPerturberType = Union[PybsmPerturber, None]
 except ImportError:


### PR DESCRIPTION
Playing with the repo. I got an error due to missing type annotations in the case where some libraries were not available. 

(Mini soap box: This sort of thing - type checking causing runtime errors - is the reason I prefer docstring-based typing or .pyi based typing).