### PR TITLE
fix(transforms): parametrize pybsm darkCurrentFromDensity call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "nrtk>=0.4.2",
     "numpy",
     "Pillow",
+    "pybsm>=0.6",
     "scikit-learn==1.5.1",
     "smqtk_image_io",
     "tabulate",

--- a/src/nrtk_explorer/library/nrtk_transforms.py
+++ b/src/nrtk_explorer/library/nrtk_transforms.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 try:
-    from pybsm.otf import darkCurrentFromDensity
+    from pybsm.otf import dark_current_from_density
     from nrtk.impls.perturb_image.generic.cv2.blur import GaussianBlurPerturber
     from nrtk.impls.perturb_image.pybsm.perturber import PybsmPerturber, PybsmSensor, PybsmScenario
 except ImportError:
@@ -99,7 +99,7 @@ def createSampleSensorAndScenario():
     intTime = 30.0e-3
 
     # dark current density of 1 nA/cm2 guess, guess mid range for a silicon camera
-    darkCurrent = darkCurrentFromDensity(1e-5, wx, wy)
+    darkCurrent = dark_current_from_density(1e-5, wx, wy)
 
     # rms read noise (rms electrons)
     readNoise = 25.0


### PR DESCRIPTION
We are failing the mypi test due to pybsm changing from darkCurrentFromDensity to dark_current_from_density function name in the latest releases.