### PR TITLE
Hugging Face Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ is built using [trame][1] by the [kitware][2] team.
 
 - Explore image datasets in COCO format.
 - Apply parametrized image degradation (such as blur) to the images.
-- Benchmark dataset resilience with a differential PCA|UMAP analysis of the
-  embeddings of the images and its transformation.
+- Benchmark dataset resilience with a differential PCA|UMAP analysis on the
+  embeddings of the images and their transformations.
 - Evaluate object detection DL models in both the source images and its
   transformations.
 - When possible it will attempt to utilize the user GPU as much as possible to
@@ -28,29 +28,41 @@ pip install nrtk-explorer
 
 ## Usage
 
-```bash
-# get some sample data
-git clone https://github.com/vicentebolea/nrtk_explorer_datasets.git
+Explore Hugging Face hosted [dataset](https://huggingface.co/datasets/rafaelpadilla/coco2017):
 
-# Run the application on given dataset
-nrtk-explorer --dataset ./nrtk_explorer_datasets/OIRDS_v1_0/oirds.json
+```bash
+nrtk-explorer --dataset rafaelpadilla/coco2017
 ```
 
-![nrtk explorer usage](https://github.com/user-attachments/assets/86a61485-471c-4b94-872e-943cb9da52a1)
+Compare inference results for Hugging Face hosted models:
 
-Some COCO image datasets available at: https://github.com/vicentebolea/nrtk_explorer_datasets/
+```bash
+nrtk-explorer --dataset cppe-5 --models qubvel-hf/detr-resnet-50-finetuned-10k-cppe5 ashaduzzaman/detr_finetuned_cppe5
+```
+
+2 COCO format datasets are available at: https://github.com/vicentebolea/nrtk_explorer_datasets/
+
+```bash
+git clone https://github.com/vicentebolea/nrtk_explorer_datasets.git
+nrtk-explorer --dataset ./nrtk_explorer_datasets/coco-od-2017/mini_val2017.json ./nrtk_explorer_datasets/OIRDS_v1_0/oirds.json
+```
 
 ## CLI flags and options
 
-- `-h|--help` show the help for the command line options, it inherit trame
+- `--dataset` specify the path to a [COCO dataset](https://roboflow.com/formats/coco-json) JSON file,
+  a [Hugging Face dataset](https://huggingface.co/datasets?task_categories=task_categories:object-detection) repository name,
+  or a directory loadable by the [Dataset](https://huggingface.co/docs/datasets/index) library.
+  You can specify multiple datasets using a space as the
+  separator. Example: `nrtk-explorer --dataset ../foo-dir/coco.json cppe-5`
+- `--download` Cache Hugging Face Hub datasets locally instead of streaming them.
+  When datasets are streamed, nrtk-explorer limits the number of loaded images.
+- `--models` specify the Hugging Face Hub [object detection](https://huggingface.co/models?pipeline_tag=object-detection&library=transformers&sort=trending)
+  repository name or a directory loadable by the [Transformers](https://huggingface.co/docs/transformers/index) library. Load multiple models using space as the separator.  
+  Example: `nrtk-explorer --models hustvl/yolos-tiny facebook/detr-resnet-50`
+- `-h|--help` show the help for the command line options. nrtk-explorer inherits the trame
   command line options and flags.
-- `--dataset` specify the path to a json file describing a COCO
-  image dataset. You can specify multiple COCO datasets using a space as the
-  separator. Example: `nrtk_explorer --dataset /foo-dir/coco.json ../bar-dir/baz.json`
-- `--models` specify the Hugging Face Hub object detection repository name to use.
-  [Possible models](https://huggingface.co/models?pipeline_tag=object-detection&library=transformers&sort=trending).
-  Specify multiple models using a space as the separator.  
-  Example: `nrtk_explorer --models hustvl/yolos-tiny facebook/detr-resnet-50`
+
+![nrtk explorer usage](https://github.com/user-attachments/assets/86a61485-471c-4b94-872e-943cb9da52a1)
 
 ## Contribute to NRTK_EXPLORER
 
@@ -66,12 +78,12 @@ pytest .
 
 For more details on setting up a development environment see [DEVELOPMENT docs](docs/source/manual/DEVELOPMENT.rst).
 
-[1]: https://trame.readthedocs.io/en/latest/
-[2]: https://www.kitware.com/
-[3]: https://cocodataset.org/
-
 ### Create release
 
 1. Merge `main` to `release` with a _merge commit_.
 2. Run "Create Release" workflow with workflow from `release` branch.
 3. Merge `release` to `main` with a _merge commit_.
+
+[1]: https://trame.readthedocs.io/en/latest/
+[2]: https://www.kitware.com/
+[3]: https://cocodataset.org/

--- a/list.py
+++ b/list.py
@@ -1,0 +1,8 @@
+from huggingface_hub import list_models
+
+models = list_models(task="object-detection", library="transformers", cardData=True)
+
+for model in models:
+    if model.card_data and model.card_data.datasets:
+        print(model.id)
+        print("datasets", model.card_data.datasets)

--- a/list.py
+++ b/list.py
@@ -1,8 +1,0 @@
-from huggingface_hub import list_models
-
-models = list_models(task="object-detection", library="transformers", cardData=True)
-
-for model in models:
-    if model.card_data and model.card_data.datasets:
-        print(model.id)
-        print("datasets", model.card_data.datasets)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "trame>=3.7",
     "trame-quasar",
     "transformers",
+    "datasets[vision]",
     "umap-learn",
     "nrtk[headless]>=0.12.0",
     "trame-annotations",

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from trame.widgets import html
 from trame_server.utils.namespace import Translator
 from nrtk_explorer.library.filtering import FilterProtocol
-from nrtk_explorer.library.dataset import get_dataset
+from nrtk_explorer.library.dataset import get_dataset, expand_hugging_face_datasets
 from nrtk_explorer.library.debounce import debounce
 
 from nrtk_explorer.app.images.images import Images
@@ -51,7 +51,8 @@ class Engine(Applet):
         )
 
         known_args, _ = self.server.cli.parse_known_args()
-        self.input_paths = known_args.dataset
+        dataset_identifiers = expand_hugging_face_datasets(known_args.dataset)
+        self.input_paths = dataset_identifiers
         self.state.current_dataset = self.input_paths[0]
 
         images = Images(server=self.server)

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -107,9 +107,8 @@ class Engine(Applet):
 
     def on_dataset_change(self, **kwargs):
         self.state.dataset_ids = []  # sampled images
-        dataset = get_dataset(self.state.current_dataset)
-        self.context.dataset = dataset
-        self.state.num_images_max = len(dataset.imgs)
+        self.context.dataset = get_dataset(self.state.current_dataset)
+        self.state.num_images_max = len(self.context.dataset.imgs)
         self.state.num_images = min(self.state.num_images_max, NUM_IMAGES_DEFAULT)
         self.state.dirty("num_images")  # Trigger resample_images()
         self.state.random_sampling_disabled = False

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -4,7 +4,7 @@ from typing import Iterable
 from trame.widgets import html
 from trame_server.utils.namespace import Translator
 from nrtk_explorer.library.filtering import FilterProtocol
-from nrtk_explorer.library.dataset import get_dataset, get_image_fpath
+from nrtk_explorer.library.dataset import get_dataset
 from nrtk_explorer.library.debounce import debounce
 
 from nrtk_explorer.app.images.images import Images
@@ -54,7 +54,6 @@ class Engine(Applet):
         self.input_paths = known_args.dataset
         self.state.current_dataset = self.input_paths[0]
 
-        self.ctrl.get_image_fpath = lambda i: get_image_fpath(i, self.state.current_dataset)
         images = Images(server=self.server)
 
         self._transforms_app = TransformsApp(
@@ -107,8 +106,9 @@ class Engine(Applet):
 
     def on_dataset_change(self, **kwargs):
         self.state.dataset_ids = []  # sampled images
-        self.context.dataset = get_dataset(self.state.current_dataset, force_reload=True)
-        self.state.num_images_max = len(self.context.dataset.imgs)
+        dataset = get_dataset(self.state.current_dataset)
+        self.context.dataset = dataset
+        self.state.num_images_max = len(dataset.imgs)
         self.state.num_images = min(self.state.num_images_max, NUM_IMAGES_DEFAULT)
         self.state.dirty("num_images")  # Trigger resample_images()
         self.state.random_sampling_disabled = False

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -47,11 +47,20 @@ class Engine(Applet):
             "--dataset",
             nargs="+",
             default=DEFAULT_DATASETS,
-            help="Path of the json file describing the image dataset",
+            help="Path to the JSON file describing the image dataset",
+        )
+
+        self.server.cli.add_argument(
+            "--download",
+            action="store_true",
+            default=False,
+            help="Download Hugging Face Hub datasets instead of streaming them",
         )
 
         known_args, _ = self.server.cli.parse_known_args()
-        dataset_identifiers = expand_hugging_face_datasets(known_args.dataset)
+        dataset_identifiers = expand_hugging_face_datasets(
+            known_args.dataset, not known_args.download
+        )
         self.input_paths = dataset_identifiers
         self.state.current_dataset = self.input_paths[0]
 

--- a/src/nrtk_explorer/app/embeddings.py
+++ b/src/nrtk_explorer/app/embeddings.py
@@ -78,7 +78,7 @@ class EmbeddingsApp(Applet):
     def on_current_dataset_change(self, **kwargs):
         self.state.num_elements_disabled = True
         if self.context.dataset is None:
-            self.context.dataset = get_dataset(self.state.current_dataset, force_reload=True)
+            self.context.dataset = get_dataset(self.state.current_dataset)
 
         self.state.num_elements_max = len(list(self.context.dataset.imgs))
         self.state.num_elements_disabled = False

--- a/src/nrtk_explorer/app/images/images.py
+++ b/src/nrtk_explorer/app/images/images.py
@@ -33,8 +33,7 @@ class Images:
         )
 
     def _load_image(self, dataset_id: str):
-        image_path = self.server.controller.get_image_fpath(int(dataset_id))
-        return Image.open(image_path)
+        return self.server.context.dataset.get_image(int(dataset_id))
 
     def get_image(self, dataset_id: str, **kwargs):
         """For cache side effects pass on_add_item and on_clear_item callbacks as kwargs"""

--- a/src/nrtk_explorer/app/images/images.py
+++ b/src/nrtk_explorer/app/images/images.py
@@ -11,23 +11,11 @@ from nrtk_explorer.app.images.cache import LruCache
 from nrtk_explorer.library.transforms import ImageTransform
 
 
-def convert_to_base64(img):
-    """Convert PIL Image to base64 string with PNG format."""
+def convert_to_base64(img: Image.Image) -> str:
+    """Convert image to base64 string"""
     buf = BytesIO()
-    try:
-        # Convert CMYK to RGB if needed
-        if img.mode == "CMYK":
-            img = img.convert("RGB")
-
-        # Save as PNG
-        img.save(buf, format="png")
-        buf.seek(0)
-
-        # Convert to base64 and add data URI prefix
-        b64_str = base64.b64encode(buf.getvalue()).decode()
-        return f"data:image/png;base64,{b64_str}"
-    finally:
-        buf.close()
+    img.save(buf, format="png")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
 
 
 IMAGE_CACHE_SIZE = 200

--- a/src/nrtk_explorer/app/images/images.py
+++ b/src/nrtk_explorer/app/images/images.py
@@ -33,7 +33,9 @@ class Images:
         )
 
     def _load_image(self, dataset_id: str):
-        return self.server.context.dataset.get_image(int(dataset_id))
+        img = self.server.context.dataset.get_image(int(dataset_id))
+        img.load()  # Avoid OSError(24, 'Too many open files')
+        return img
 
     def get_image(self, dataset_id: str, **kwargs):
         """For cache side effects pass on_add_item and on_clear_item callbacks as kwargs"""

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -27,7 +27,6 @@ from nrtk_explorer.app.images.image_ids import (
     dataset_id_to_image_id,
     dataset_id_to_transformed_image_id,
 )
-from nrtk_explorer.library.dataset import get_dataset
 from nrtk_explorer.app.images.images import Images
 from nrtk_explorer.app.images.stateful_annotations import (
     make_stateful_annotations,

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -204,10 +204,6 @@ class TransformsApp(Applet):
 
         self.visible_dataset_ids = []  # set by ImageList via self.on_scroll callback
 
-    @property
-    def get_image_fpath(self):
-        return self.server.controller.get_image_fpath
-
     def on_server_ready(self, *args, **kwargs):
         self.state.change("object_detection_model")(self.on_object_detection_model_change)
         self.on_object_detection_model_change()

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -324,10 +324,9 @@ class TransformsApp(Applet):
         annotations = self.original_detection_annotations.get_annotations(
             self.detector, image_id_to_image
         )
-        dataset = get_dataset(self.state.current_dataset)
         self.predictions_original_images = convert_from_predictions_to_first_arg(
             annotations,
-            dataset,
+            self.context.dataset,
             dataset_ids,
         )
 

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -6,6 +6,7 @@ Example:
 """
 
 from typing import Sequence as SequenceType
+import os
 from functools import lru_cache
 from pathlib import Path
 import json
@@ -13,31 +14,40 @@ from PIL import Image
 from datasets import (
     load_dataset,
     get_dataset_infos,
-    Sequence,
+    Sequence as SequenceDataset,
     ClassLabel,
 )
 
+HF_ROWS_MAX_TO_DOWNLOAD = 5000
+HF_ROWS_TO_TAKE_STREAMING = 600
 
-class JsonDataset:
-    """Read a COCO JSON and get the image file path given an image id."""
+
+class BaseDataset:
+
+    def get_image(self, id: int):
+        """Get the image given an image id."""
+        img = self._get_image(id)
+        return img.convert("RGB") if img.mode != "RGB" else img
+
+
+class JsonDataset(BaseDataset):
+    """JSON-based COCO datasets."""
 
     def __init__(self, path: str):
         with open(path) as f:
             self.data = json.load(f)
-            self.fpath = path
-            self.cats = {cat["id"]: cat for cat in self.data["categories"]}
-            self.anns = {ann["id"]: ann for ann in self.data["annotations"]}
-            self.imgs = {img["id"]: img for img in self.data["images"]}
+        self.fpath = path
+        self.cats = {cat["id"]: cat for cat in self.data["categories"]}
+        self.anns = {ann["id"]: ann for ann in self.data["annotations"]}
+        self.imgs = {img["id"]: img for img in self.data["images"]}
 
-    def get_image_fpath(self, selected_id: int):
-        """Get the image file path given an image id."""
+    def _get_image_fpath(self, selected_id: int):
         dataset_dir = Path(self.fpath).parent
         file_name = self.imgs[selected_id]["file_name"]
         return str(dataset_dir / file_name)
 
-    def get_image(self, id: int):
-        """Get the image given an image id."""
-        image_fpath = self.get_image_fpath(id)
+    def _get_image(self, id: int):
+        image_fpath = self._get_image_fpath(id)
         return Image.open(image_fpath)
 
 
@@ -45,28 +55,21 @@ def make_coco_dataset(path: str):
     try:
         import kwcoco
 
-        class NrtkCocoDataset(kwcoco.CocoDataset):
-            def get_image(self, id: int):
-                """Get the image given an image id."""
-                image_fpath = self.get_image_fpath(id)
-                return Image.open(image_fpath)
+        class CocoDataset(kwcoco.CocoDataset, BaseDataset):
+            pass
 
-        return NrtkCocoDataset(path)
+        return CocoDataset(path)
     except ImportError:
         return JsonDataset(path)
 
 
 def is_coco_dataset(path: str):
-    """Check if the file is a COCO dataset JSON."""
-    import os
-
     if not os.path.exists(path):
         return False
-
     required_keys = ['"images"', '"categories"', '"annotations"']
     with open(path) as f:
         content = f.read()
-        return all(key in content for key in required_keys)
+    return all(key in content for key in required_keys)
 
 
 def expand_hugging_face_datasets(dataset_identifiers: SequenceType[str]):
@@ -82,39 +85,20 @@ def expand_hugging_face_datasets(dataset_identifiers: SequenceType[str]):
     return expanded_identifiers
 
 
-HF_ROWS_MAX_TO_DOWNLOAD = 5000
-HF_ROWS_TO_TAKE_STREAMING = 600
-
-
-class HuggingFaceDataset:
-    """Interface to Hugging Face Dataset with the same API as JsonDataset."""
+class HuggingFaceDataset(BaseDataset):
+    """Interface for Hugging Face datasets with a similar API to JsonDataset."""
 
     def __init__(self, identifier: str):
-        parts = identifier.split("@")
-        if len(parts) == 3:
-            repo_name, selected_config_name, selected_split_name = parts
-        else:
-            raise ValueError("Identifier must be in the format 'dataset@config@split'")
-
-        infos = get_dataset_infos(repo_name)
-        selected_info = infos[selected_config_name]
-        split = selected_info.splits[selected_split_name]
-        self._streaming = (
-            getattr(split, "num_examples", HF_ROWS_MAX_TO_DOWNLOAD + 1) > HF_ROWS_MAX_TO_DOWNLOAD
-        )
-
-        self._dataset = load_dataset(
-            repo_name, selected_config_name, split=selected_split_name, streaming=self._streaming
-        )
-
+        repo, config, split = identifier.split("@")
+        infos = get_dataset_infos(repo)[config]
+        self._streaming = infos.splits[split].num_examples > HF_ROWS_MAX_TO_DOWNLOAD
+        self._dataset = load_dataset(repo, config, split=split, streaming=self._streaming)
         if self._streaming:
             self._dataset = self._dataset.take(HF_ROWS_TO_TAKE_STREAMING)
-
         self.imgs = {}
         self.anns = {}
         self.cats = {}
         self._id_to_row_idx = {}
-
         self._load_data()
 
     def _load_data(self):
@@ -130,7 +114,7 @@ class HuggingFaceDataset:
                 return feature.names
             if hasattr(feature, "names"):
                 return feature.names
-            if isinstance(feature, Sequence):
+            if isinstance(feature, SequenceDataset):
                 return extract_labels(feature.feature)
             if isinstance(feature, dict):
                 for key in ["category", "label"]:
@@ -148,28 +132,26 @@ class HuggingFaceDataset:
             self.cats = {i: {"id": i, "name": str(name)} for i, name in enumerate(labels)}
 
         new_cats = set()
-        ds_iterator = self._dataset if self._streaming else self._dataset.remove_columns("image")
-        for idx, example in enumerate(ds_iterator):
+        for idx, example in enumerate(self._dataset):
             id = example.get("id", example.get("image_id", idx))
-            self.imgs[id] = {"id": id}
-            self._id_to_row_idx[id] = example["image"] if self._streaming else idx
+            if self._streaming:
+                self.imgs[id] = {"id": id, "image": example["image"]}
+            else:
+                self.imgs[id] = {"id": id}
+                self._id_to_row_idx[id] = idx
 
             if "objects" in example:
                 objects = example["objects"]
                 dataset_has_ids = True
-                ids = objects.get("id", objects.get("bbox_id"))
-                if ids is None:
-                    ids = [make_id() for _ in range(len(objects["bbox"]))]
-                    dataset_has_ids = False
-
-                categories = objects.get("category", objects.get("label"))
-                for annotation_id, bbox, category_id in zip(ids, objects["bbox"], categories):
-                    if category_id not in self.cats:
-                        new_cats.add(category_id)
-                    self.anns[annotation_id] = {
-                        "id": annotation_id if dataset_has_ids else None,
+                ids = objects.get("id") or [make_id() for _ in range(len(objects.get("bbox", [])))]
+                categories = objects.get("category") or objects.get("label", [])
+                for ann_id, bbox, cat_id in zip(ids, objects.get("bbox", []), categories):
+                    if cat_id not in self.cats:
+                        new_cats.add(cat_id)
+                    self.anns[ann_id] = {
+                        "id": ann_id if dataset_has_ids else None,
                         "image_id": id,
-                        "category_id": category_id,
+                        "category_id": cat_id,
                         "bbox": bbox,
                     }
 
@@ -184,32 +166,13 @@ class HuggingFaceDataset:
 
     def _get_image(self, id):
         if self._streaming:
-            return self._id_to_row_idx[id]
-        row = self._id_to_row_idx[id]
-        return self._dataset[row]["image"]
-
-    def get_image(self, id):
-        """Get the image given an image id."""
-        img = self._get_image(id)
-        # transform filters and to converting to base64 requires RGB
-        if img.mode != "RGB":
-            return img.convert("RGB")
-        return img
+            return self.imgs[id]["image"]
+        else:
+            row_idx = self._id_to_row_idx[id]
+            return self._dataset[row_idx]["image"]
 
 
 @lru_cache
-def __load_dataset(identifier: str):
-    """Load the dataset."""
-
-    absolute_path = str(Path(identifier).resolve())
-
-    if is_coco_dataset(absolute_path):
-        return make_coco_dataset(absolute_path)
-
-    # Assume identifier is a Hugging Face Dataset
-    return HuggingFaceDataset(identifier)
-
-
 def get_dataset(identifier: str):
     """Get the dataset object.
     Args:
@@ -217,4 +180,10 @@ def get_dataset(identifier: str):
     Return:
         dataset: Dataset object.
     """
-    return __load_dataset(identifier)
+    absolute_path = str(Path(identifier).resolve())
+
+    if is_coco_dataset(absolute_path):
+        return make_coco_dataset(absolute_path)
+
+    # Assume identifier is a Hugging Face Dataset
+    return HuggingFaceDataset(identifier)

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -182,12 +182,19 @@ class HuggingFaceDataset:
             for annotation in self.anns.values():
                 annotation["category_id"] = name_to_id[annotation["category_id"]]
 
-    def get_image(self, id):
-        """Get the image given an image id."""
+    def _get_image(self, id):
         if self._streaming:
             return self._id_to_row_idx[id]
         row = self._id_to_row_idx[id]
         return self._dataset[row]["image"]
+
+    def get_image(self, id):
+        """Get the image given an image id."""
+        img = self._get_image(id)
+        # transform filters and to converting to base64 requires RGB
+        if img.mode != "RGB":
+            return img.convert("RGB")
+        return img
 
 
 @lru_cache

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -26,6 +26,7 @@ class BaseDataset:
     def get_image(self, id: int):
         """Get the image given an image id."""
         img = self._get_image(id)
+        # transforms and base64 encoding require RGB mode
         return img.convert("RGB") if img.mode != "RGB" else img
 
 
@@ -55,7 +56,9 @@ def make_coco_dataset(path: str):
         import kwcoco
 
         class CocoDataset(kwcoco.CocoDataset, BaseDataset):
-            pass
+            def _get_image(self, id: int):
+                image_fpath = self.get_image_fpath(id)
+                return Image.open(image_fpath)
 
         return CocoDataset(path)
     except ImportError:

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -127,17 +127,14 @@ class HuggingFaceDataset(BaseDataset):
             if isinstance(feature, list):
                 return extract_labels(feature[0])
             if isinstance(feature, dict):
-                for key in ["category", "category_id", "label"]:
+                for key in ["category", "category_id", "label", "labels", "objects"]:
                     if key in feature:
-                        return extract_labels(feature[key])
+                        labels = extract_labels(feature[key])
+                        if labels:
+                            return labels
             return None
 
-        features = self._dataset.features
-        labels = None
-        if "labels" in features:
-            labels = extract_labels(features["labels"])
-        if not labels and "objects" in features:
-            labels = extract_labels(features["objects"])
+        labels = extract_labels(self._dataset.features)
         if labels:
             self.cats = {i: {"id": i, "name": str(name)} for i, name in enumerate(labels)}
 

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -1,15 +1,14 @@
 """
-Module to load the dataset and get the image file path given an image id.
+Module to load a dataset.
 
 Example:
     dataset = get_dataset("path/to/dataset.json")
-    image_fpath = dataset.get_image_fpath(image_id)
 """
 
 from functools import lru_cache
 from pathlib import Path
-
 import json
+from PIL import Image
 
 
 class JsonDataset:
@@ -29,19 +28,162 @@ class JsonDataset:
         file_name = self.imgs[selected_id]["file_name"]
         return str(dataset_dir / file_name)
 
+    def get_image(self, id: int):
+        """Get the image given an image id."""
+        image_fpath = self.get_image_fpath(id)
+        return Image.open(image_fpath)
 
-@lru_cache
-def __load_dataset(path: str):
-    """Load the dataset given the path to the dataset file."""
+
+def make_coco_dataset(path: str):
     try:
         import kwcoco
 
-        return kwcoco.CocoDataset(path)
+        class NrtkCocoDataset(kwcoco.CocoDataset):
+            def get_image(self, id: int):
+                """Get the image given an image id."""
+                image_fpath = self.get_image_fpath(id)
+                return Image.open(image_fpath)
+
+        return NrtkCocoDataset(path)
     except ImportError:
         return JsonDataset(path)
 
 
-def get_dataset(path: str, force_reload: bool = False):
+def is_coco_dataset(path: str):
+    """Check if the file is a COCO dataset JSON."""
+    import os
+
+    if not os.path.exists(path):
+        return False
+
+    required_keys = ['"images"', '"categories"', '"annotations"']
+    with open(path) as f:
+        content = f.read()
+        return all(key in content for key in required_keys)
+
+
+class HuggingFaceDataset:
+    """Interface to Hugging Face Dataset with the same API as JsonDataset."""
+
+    def __init__(self, identifier: str):
+        from datasets import load_dataset, get_dataset_default_config_name, get_dataset_infos
+
+        infos = get_dataset_infos(identifier)
+        selected_split_name = None
+        selected_config_name = get_dataset_default_config_name(identifier)
+        if selected_config_name is None:
+            max_rows = 0
+            for config_name, info in infos.items():
+                for split_name, split_info in info.splits.items():
+                    if split_info.num_examples > max_rows:
+                        max_rows = split_info.num_examples
+                        selected_config_name = config_name
+                        selected_split_name = split_name
+        if selected_split_name is None:
+            split_infos = infos[selected_config_name].splits
+            selected_split_name, _ = max(
+                split_infos.items(),
+                key=lambda item: item[1].num_examples,
+            )
+
+        self.dataset = load_dataset(identifier, selected_config_name, split=selected_split_name)
+        self.cats = self._load_categories()
+        self.anns = self._load_annotations()
+        self.imgs = self._load_images()
+
+    def _load_categories(self):
+        if "labels" in self.dataset.features:
+            labels = self.dataset.features["labels"].names
+            return {i: {"id": i, "name": name} for i, name in enumerate(labels)}
+
+        if "objects" in self.dataset.features:
+            labels = self.dataset.features["objects"].feature["category"].names
+            return {i: {"id": i, "name": name} for i, name in enumerate(labels)}
+        return {}
+
+    def _load_annotations(self):
+        annotations = {}
+        for idx, example in enumerate(self.dataset):
+            if "objects" in example:
+                objects = example["objects"]
+                image_id = example.get("id", idx)
+                id_key = "id" if "id" in objects else "bbox_id"
+                for obj_id, bbox, category_id in zip(
+                    objects[id_key], objects["bbox"], objects["category"]
+                ):
+                    annotations[obj_id] = {
+                        "id": obj_id,
+                        "image_id": image_id,
+                        "category_id": category_id,
+                        "bbox": bbox,
+                    }
+
+        counter = 1
+
+        def get_id(annotations):
+            nonlocal counter
+            """Generate a unique string ID not present in annotations."""
+            while True:
+                new_id = f"ann_{counter}"
+                if new_id not in annotations:
+                    return new_id
+                counter += 1
+
+        for idx, example in enumerate(self.dataset):
+            if "labels" in example:
+                image = example["image"]
+                annotation_id = get_id(annotations)
+                annotations[annotation_id] = {
+                    "id": annotation_id,
+                    "image_id": idx,
+                    "category_id": example["labels"],
+                    "bbox": [2, 2, image.width - 2, image.height - 2],
+                }
+
+        return annotations
+
+    def _load_images(self):
+        images = {}
+        for idx, example in enumerate(self.dataset):
+            image = example["image"]
+            id = example.get("id", idx)
+            images[id] = {
+                "id": id,
+                "height": image.height,
+                "width": image.width,
+            }
+        return images
+
+    def get_image_fpath(self, selected_id: int):
+        """Get the image file path given an image id."""
+        image = self.imgs.get(selected_id)
+        if image:
+            return image["file_name"]
+        raise KeyError(f"Image ID {selected_id} not found.")
+
+    def get_image(self, id: int):
+        """Get the image given an image id."""
+        return self.dataset[id]["image"]
+
+
+def wrap_hugging_face_dataset(identifier):
+    return HuggingFaceDataset(identifier)
+
+
+@lru_cache
+def __load_dataset(identifier: str):
+    """Load the dataset given the path to the dataset file."""
+
+    absolute_path = str(Path(identifier).resolve())
+
+    if is_coco_dataset(absolute_path):
+        return make_coco_dataset(absolute_path)
+
+    # Assume identifier is a Hugging Face Dataset
+    return wrap_hugging_face_dataset(identifier)
+
+
+def get_dataset(identifier: str, force_reload: bool = False):
     """Get the dataset object given the path to the dataset file.
     Args:
         path (str): Path to the dataset file.
@@ -51,8 +193,7 @@ def get_dataset(path: str, force_reload: bool = False):
     """
     if force_reload:
         __load_dataset.cache_clear()
-    absolute_path = str(Path(path).resolve())
-    return __load_dataset(absolute_path)
+    return __load_dataset(identifier)
 
 
 def get_image_fpath(selected_id: int, path: str):

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import json
 
 
-class DefaultDataset:
-    """Default dataset class to load the dataset and get the image file path given an image id."""
+class JsonDataset:
+    """Read a COCO JSON and get the image file path given an image id."""
 
     def __init__(self, path: str):
         with open(path) as f:
@@ -38,7 +38,7 @@ def __load_dataset(path: str):
 
         return kwcoco.CocoDataset(path)
     except ImportError:
-        return DefaultDataset(path)
+        return JsonDataset(path)
 
 
 def get_dataset(path: str, force_reload: bool = False):

--- a/src/nrtk_explorer/library/dataset.py
+++ b/src/nrtk_explorer/library/dataset.py
@@ -6,6 +6,7 @@ Example:
 """
 
 from typing import Sequence as SequenceType
+from abc import ABC, abstractmethod
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -21,7 +22,10 @@ from datasets import (
 HF_ROWS_TO_TAKE_STREAMING = 300
 
 
-class BaseDataset:
+class BaseDataset(ABC):
+    @abstractmethod
+    def _get_image(self, id: int):
+        pass
 
     def get_image(self, id: int):
         """Get the image given an image id."""
@@ -99,10 +103,10 @@ class HuggingFaceDataset(BaseDataset):
         self._dataset = load_dataset(repo, config, split=split, streaming=self._streaming)
         if self._streaming:
             self._dataset = self._dataset.take(HF_ROWS_TO_TAKE_STREAMING)
-        self.imgs = {}
-        self.anns = {}
-        self.cats = {}
-        self._id_to_row_idx = {}
+        self.imgs: dict[str, dict] = {}
+        self.anns: dict[str, dict] = {}
+        self.cats: dict[str, dict] = {}
+        self._id_to_row_idx: dict[str, int] = {}
         self._load_data()
 
     def _load_data(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,4 +1,4 @@
-from nrtk_explorer.library.dataset import get_dataset, DefaultDataset
+from nrtk_explorer.library.dataset import get_dataset, JsonDataset
 import nrtk_explorer.test_data
 
 from unittest import mock
@@ -26,14 +26,14 @@ def test_get_dataset(dataset_path):
     assert ds1 is not ds2
 
 
-@mock.patch("nrtk_explorer.library.dataset.__load_dataset", lambda path: DefaultDataset(path))
+@mock.patch("nrtk_explorer.library.dataset.__load_dataset", lambda path: JsonDataset(path))
 def test_get_dataset_empty():
     with pytest.raises(FileNotFoundError):
         get_dataset("nonexisting")
 
 
 def test_DefaultDataset(dataset_path):
-    ds = DefaultDataset(dataset_path)
+    ds = JsonDataset(dataset_path)
     assert len(ds.imgs) > 0
     assert len(ds.cats) > 0
     assert len(ds.anns) > 0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -21,10 +21,6 @@ def test_get_dataset(dataset_path):
     ds2 = get_dataset(dataset_path)
     assert ds1 is ds2
 
-    ds1 = get_dataset(dataset_path)
-    ds2 = get_dataset(dataset_path, force_reload=True)
-    assert ds1 is not ds2
-
 
 @mock.patch("nrtk_explorer.library.dataset.__load_dataset", lambda path: JsonDataset(path))
 def test_get_dataset_empty():
@@ -37,4 +33,4 @@ def test_DefaultDataset(dataset_path):
     assert len(ds.imgs) > 0
     assert len(ds.cats) > 0
     assert len(ds.anns) > 0
-    assert Path(ds.get_image_fpath(491497)).name == "000000491497.jpg"
+    assert ds.get_image(next(iter(ds.imgs.keys()))) is not None

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,6 @@
 from nrtk_explorer.library.dataset import get_dataset, JsonDataset
 import nrtk_explorer.test_data
 
-from unittest import mock
 from pathlib import Path
 
 import pytest
@@ -22,9 +21,8 @@ def test_get_dataset(dataset_path):
     assert ds1 is ds2
 
 
-@mock.patch("nrtk_explorer.library.dataset.__load_dataset", lambda path: JsonDataset(path))
 def test_get_dataset_empty():
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError):
         get_dataset("nonexisting")
 
 


### PR DESCRIPTION
Test it out:
`nrtk-explorer --dataset cppe-5 beans rafaelpadilla/coco2017 keremberke/german-traffic-sign-detection mrtoy/mobile-ui-design keremberke/construction-safety-object-detection keremberke/table-extraction`

Use the `--download` CLI arg to cache the Hugging Face dataset localy.  Dataset streaming is the default.
`nrtk-explorer --dataset cppe-5 --download`

Adds a `dataset[vision]` dependency.

Object Detection task tagged datasets:
https://huggingface.co/datasets?task_categories=task_categories:object-detection
Does not support them all =/