### PR TITLE
Update nrtk and pybsm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ For more details on setting up a development environment see [DEVELOPMENT docs](
 1. Merge `main` to `release` with a _merge commit_.
 2. Run "Create Release" workflow with workflow from `release` branch.
 3. Merge `release` to `main` with a _merge commit_.
+4. Check package versions in Conda Feedstock [meta.yaml file](https://github.com/conda-forge/nrtk-explorer-feedstock/blob/main/recipe/meta.yaml)
 
 [1]: https://trame.readthedocs.io/en/latest/
 [2]: https://www.kitware.com/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "accelerate",
     "numpy",
     "Pillow",
-    "pybsm>=0.6,<=0.9.0",
+    "pybsm==0.10.2",
     "scikit-learn>=1.6.0",
     "smqtk_image_io",
     "tabulate",
@@ -42,7 +42,7 @@ dependencies = [
     "transformers",
     "datasets[vision]",
     "umap-learn",
-    "nrtk[headless]>=0.12.0,<=0.16.0",
+    "nrtk[headless]==0.19.1",
     "trame-annotations>=0.4.0",
     "kwcoco",
 ]

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -173,9 +173,6 @@ class TransformsApp(Applet):
             "identity": trans.IdentityTransform,
         }
 
-        if nrtk_trans.nrtk_transforms_available():
-            self._transform_classes["nrtk_pybsm"] = nrtk_trans.NrtkPybsmTransform
-
         # Add transform from YAML definition
         self._transform_classes.update(nrtk_yaml.generate_transforms())
 

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -8,7 +8,6 @@ from trame.app import get_server, asynchronous
 from trame_server import Server
 
 import nrtk_explorer.library.transforms as trans
-import nrtk_explorer.library.nrtk_transforms as nrtk_trans
 import nrtk_explorer.library.yaml_transforms as nrtk_yaml
 from nrtk_explorer.library import object_detector
 from nrtk_explorer.library.app_config import process_config

--- a/src/nrtk_explorer/library/nrtk_transforms.yaml
+++ b/src/nrtk_explorer/library/nrtk_transforms.yaml
@@ -115,10 +115,10 @@ nrtk_pybsm_detector_otf:
       type: float
       label: Focal length (m)
 
-nrtk_pybsm_2:
+nrtk_pybsm:
   perturber: nrtk.impls.perturb_image.pybsm.perturber.PybsmPerturber
   perturber_kwargs: nrtk_explorer.library.nrtk_transforms.create_sample_sensor_and_scenario
-  exec_default_args: [{ img_gsd: 0.15 }]
+  exec_default_args: [None, { img_gsd: 0.15 }]
   description:
     D:
       _path: [sensor, D]

--- a/src/nrtk_explorer/library/yaml_transforms.py
+++ b/src/nrtk_explorer/library/yaml_transforms.py
@@ -152,6 +152,6 @@ class MetaYamlPerturber(type):
             input_args = self.exec_args
 
         input_array = np.asarray(input)
-        output_array = self._perturber.perturb(input_array, *input_args)
+        output_array, _ = self._perturber.perturb(input_array, *input_args)
 
         return ImageModule.fromarray(output_array)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -14,6 +14,6 @@ def test_gaussian_blur():
 
 def test_pybsm():
     transforms = generate_transforms()
-    pybsm = transforms["nrtk_pybsm_2"]()
+    pybsm = transforms["nrtk_pybsm"]()
     pybsm.set_parameters({"D": 0.25, "f": 4.0})
     pybsm.execute(get_image())


### PR DESCRIPTION
PR pins the versions of  `nrtk` and `pybsm`.  These packages often have breaking changes.  This means our testing cron job is less interesting, but keeping it still: https://github.com/Kitware/nrtk-explorer/blob/main/.github/workflows/ci.yml#L7

- [x] fix pybsm transform
- [x] update nrtk version

closes #152

After release on PiPy, update Conda feedstock: https://github.com/conda-forge/nrtk-explorer-feedstock/pull/16