### PR TITLE
Category filter tweeks

### DIFF
--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -162,6 +162,7 @@ class Engine(Applet):
             selected_images = images
 
         self.state.dataset_ids = [str(img["id"]) for img in selected_images]
+        self.state.user_selected_ids = self.state.dataset_ids
 
     def _build_ui(self):
         extra_args = {}

--- a/src/nrtk_explorer/app/embeddings.py
+++ b/src/nrtk_explorer/app/embeddings.py
@@ -148,7 +148,6 @@ class EmbeddingsApp(Applet):
 
         self.clear_points_transformations()
 
-        self.state.user_selected_ids = []
         self.state.camera_position = []
 
         with self.state:
@@ -174,8 +173,12 @@ class EmbeddingsApp(Applet):
         updated_points = {image_id_to_dataset_id(id): point for id, point in zip(ids, points)}
         self.state.points_transformations = {**self.state.points_transformations, **updated_points}
 
+    # called by category filter
     def on_select(self, image_ids):
         self.state.user_selected_ids = image_ids
+
+    def on_scatter_select(self, image_ids):
+        self.state.user_selected_ids = image_ids or self.state.dataset_ids
 
     def on_move(self, camera_position):
         self.state.camera_position = camera_position
@@ -212,7 +215,7 @@ class EmbeddingsApp(Applet):
             hover=(self.on_point_hover, "[$event]"),
             points=("points_sources", {}),
             transformedPoints=("points_transformations", {}),
-            select=(self.on_select, "[$event]"),
+            select=(self.on_scatter_select, "[$event]"),
             selectedPoints=("user_selected_ids", []),
         )
 

--- a/src/nrtk_explorer/app/ui/image_list.py
+++ b/src/nrtk_explorer/app/ui/image_list.py
@@ -132,12 +132,9 @@ class ImageList(html.Div):
                     self.state[key] = None
         self.state.image_list_ids = dataset_ids
 
-    @change("dataset_ids", "user_selected_ids")
+    @change("user_selected_ids")
     def update_image_list_ids(self, **kwargs):
-        if len(self.state.user_selected_ids) > 0:
-            self._set_image_list_ids(self.state.user_selected_ids)
-        else:
-            self._set_image_list_ids(self.state.dataset_ids)
+        self._set_image_list_ids(self.state.user_selected_ids)
 
     @change("image_list_ids")
     def reset_view_range(self, **kwargs):

--- a/vue-components/src/components/FilterOptionsWidget.vue
+++ b/vue-components/src/components/FilterOptionsWidget.vue
@@ -34,11 +34,15 @@ function onChipClick(value: Category) {
 
   emit('update:modelValue', newValue)
 }
+
+const alphabetizedOptions = computed(() => {
+  return Object.values(props.options).sort((a, b) => a.name.localeCompare(b.name))
+})
 </script>
 
 <template>
   <q-chip
-    v-for="option in options"
+    v-for="option in alphabetizedOptions"
     :key="option.id"
     :color="modelValueSet.has(option.id) ? 'primary' : ''"
     :text-color="modelValueSet.has(option.id) ? 'white' : ''"


### PR DESCRIPTION
Now, the image list always shows the selected images.  So now all images are selected after loading dataset or clicking on blank space in embeddings plot.  Also, when the Category filter turns up no images, no images are shown in the image list.