### PR TITLE
Fix sorting on scores

### DIFF
--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -40,7 +40,7 @@ DIR_NAME = os.path.dirname(nrtk_explorer.test_data.__file__)
 DEFAULT_DATASETS = [
     f"{DIR_NAME}/coco-od-2017/test_val2017.json",
 ]
-NUM_IMAGES_DEFAULT = 500
+NUM_IMAGES_DEFAULT = 200
 NUM_IMAGES_DEBOUNCE_TIME = 0.3  # seconds
 
 

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -40,7 +40,7 @@ DIR_NAME = os.path.dirname(nrtk_explorer.test_data.__file__)
 DEFAULT_DATASETS = [
     f"{DIR_NAME}/coco-od-2017/test_val2017.json",
 ]
-NUM_IMAGES_DEFAULT = 200
+NUM_IMAGES_DEFAULT = 500
 NUM_IMAGES_DEBOUNCE_TIME = 0.3  # seconds
 
 

--- a/src/nrtk_explorer/app/core.py
+++ b/src/nrtk_explorer/app/core.py
@@ -136,6 +136,7 @@ class Engine(Applet):
         self.ctrl.on_server_reload = self._build_ui
         self.ctrl.add("on_server_ready")(self.on_server_ready)
 
+        self.state.num_images = NUM_IMAGES_DEFAULT
         self.state.num_images_max = 0
         self.state.num_images_disabled = True
         self.state.random_sampling = False
@@ -164,7 +165,7 @@ class Engine(Applet):
         self.state.dataset_ids = []  # sampled images
         self.context.dataset = get_dataset(self.state.current_dataset)
         self.state.num_images_max = len(self.context.dataset.imgs)
-        self.state.num_images = min(self.state.num_images_max, NUM_IMAGES_DEFAULT)
+        self.state.num_images = min(self.state.num_images_max, self.state.num_images)
         self.state.dirty("num_images")  # Trigger resample_images()
         self.state.random_sampling_disabled = False
         self.state.num_images_disabled = False
@@ -188,19 +189,19 @@ class Engine(Applet):
         self._embeddings_app.on_select(selected_ids)
 
     def resample_images(self, **kwargs):
-        images = list(self.context.dataset.imgs.values())
+        ids = [image["id"] for image in self.context.dataset.imgs.values()]
 
         selected_images = []
         if self.state.num_images:
             if self.state.random_sampling:
-                selected_images = random.sample(images, min(len(images), self.state.num_images))
+                selected_images = random.sample(ids, min(len(ids), self.state.num_images))
             else:
-                selected_images = images[: self.state.num_images]
+                selected_images = ids[: self.state.num_images]
         else:
-            selected_images = images
+            selected_images = ids
 
-        self.context.dataset_ids = [img["id"] for img in selected_images]
-        self.state.dataset_ids = [str(image_id) for image_id in self.context.dataset_ids]
+        self.context.dataset_ids = selected_images
+        self.state.dataset_ids = [str(id) for id in self.context.dataset_ids]
         self.state.user_selected_ids = self.state.dataset_ids
 
     def _build_ui(self):

--- a/src/nrtk_explorer/app/embeddings.py
+++ b/src/nrtk_explorer/app/embeddings.py
@@ -40,7 +40,7 @@ class EmbeddingsApp(Applet):
         if self.is_standalone_app and datasets:
             self.state.dataset_ids = []
             self.state.current_dataset = datasets[0]
-            self.on_current_dataset_change()
+            self.context.dataset = get_dataset(self.state.current_dataset)
 
         self.features = None
 
@@ -55,10 +55,6 @@ class EmbeddingsApp(Applet):
         }
 
     def on_server_ready(self, *args, **kwargs):
-        # Bind instance methods to state change
-        self.on_current_dataset_change()
-        self.state.change("current_dataset")(self.on_current_dataset_change)
-
         self.on_feature_extraction_model_change()
         self.state.change("feature_extraction_model")(self.on_feature_extraction_model_change)
 
@@ -73,14 +69,6 @@ class EmbeddingsApp(Applet):
         self.extractor = embeddings_extractor.EmbeddingsExtractor(
             model_name=feature_extraction_model
         )
-
-    def on_current_dataset_change(self, **kwargs):
-        self.state.num_elements_disabled = True
-        if self.context.dataset is None:
-            self.context.dataset = get_dataset(self.state.current_dataset)
-
-        self.state.num_elements_max = len(list(self.context.dataset.imgs))
-        self.state.num_elements_disabled = False
 
     def compute_points(self, fit_features, features):
         if len(features) == 0:
@@ -114,7 +102,7 @@ class EmbeddingsApp(Applet):
         )
 
     def clear_points_transformations(self, **kwargs):
-        self.state.points_transformations = {}  # ID to point
+        self.state.points_transformations = {}  # datset ID to point
         self._stashed_points_transformations = {}
 
     def update_points_transformations_state(self, **kwargs):

--- a/src/nrtk_explorer/app/images/annotations.py
+++ b/src/nrtk_explorer/app/images/annotations.py
@@ -75,7 +75,7 @@ class DetectionAnnotations:
         )
 
         to_detect = {id: id_to_image[id] for id in misses}
-        predictions = predictor.infer(to_detect)
+        predictions = await predictor.infer(to_detect)
         for id, annotations in predictions.items():
             self.cache.add_item(
                 id, annotations, self.add_to_cache_callback, self.delete_from_cache_callback

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Dict, Callable
+from collections.abc import Mapping
 
 from trame.ui.quasar import QLayout
 from trame.widgets import quasar
@@ -43,8 +44,34 @@ INFERENCE_MODELS_DEFAULT = [
 ]
 
 
+UPDATE_IMAGES_CHUNK_SIZE = 32
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+class LazyDict(Mapping):
+    def __init__(self, *args, **kw):
+        self._raw_dict = dict(*args, **kw)
+
+    def __getitem__(self, key):
+        val = self._raw_dict[key]
+        return val() if callable(val) else val
+
+    def __setitem__(self, key, value):
+        self._raw_dict[key] = value
+
+    def __iter__(self):
+        return iter(self._raw_dict)
+
+    def __len__(self):
+        return len(self._raw_dict)
+
+    def values(self):
+        return (self[k] for k in self._raw_dict)
+
+    def items(self):
+        return ((k, self[k]) for k in self._raw_dict)
 
 
 class ProcessingStep:
@@ -156,6 +183,8 @@ class TransformsApp(Applet):
                     delete_state(self.state, dataset_id_to_meta(id))
 
         change_checker(self.state, "dataset_ids")(delete_meta_state)
+        # clear score when changing model
+        # clear score when changing transform
 
         self._parameters_app = ParametersApp(
             server=server,
@@ -197,7 +226,7 @@ class TransformsApp(Applet):
             feature_enabled_state_key="transform_enabled",
             gui_switch_key="transform_enabled_switch",
             column_name=TRANSFORM_COLUMNS[0],
-            enabled_callback=self._start_transformed_images,
+            enabled_callback=self._start_update_images,
         )
 
         self.server.controller.on_server_ready.add(self.on_server_ready)
@@ -232,44 +261,32 @@ class TransformsApp(Applet):
     def on_apply_transform(self, **kwargs):
         # Turn on switch if user clicked lower apply button
         self.state.transform_enabled_switch = True
-        self._start_transformed_images()
+        self._start_update_images()
 
-    def _start_transformed_images(self, *args, **kwargs):
-        logger.debug("_start_transformed_images")
-        if self._updating_images():
-            if self._updating_transformed_images:
-                # computing stale transformed images, restart task
-                self._cancel_update_images()
-            else:
-                return  # update_images will call update_transformed_images() at the end
-        self._update_task = asynchronous.create_task(
-            self.update_transformed_images(self.visible_dataset_ids)
-        )
-
-    async def update_transformed_images(self, dataset_ids):
-        self._updating_transformed_images = True
-        try:
-            await self._update_transformed_images(dataset_ids)
-        finally:
-            self._updating_transformed_images = False
-
-    async def _update_transformed_images(self, dataset_ids):
+    async def update_transformed_images(self, dataset_ids, visible=False):
         if not self.state.transform_enabled:
             return
 
         transforms = list(map(lambda t: t["instance"], self.context.transforms))
         transform = trans.ChainedImageTransform(transforms)
 
-        id_to_matching_size_img = {}
+        id_to_image = LazyDict()
         for id in dataset_ids:
-            with self.state:
-                transformed = self.images.get_stateful_transformed_image(transform, id)
-                id_to_matching_size_img[dataset_id_to_transformed_image_id(id)] = transformed
-            await self.server.network_completion
+            if visible:
+                with self.state:
+                    transformed = self.images.get_stateful_transformed_image(transform, id)
+                    id_to_image[dataset_id_to_transformed_image_id(id)] = transformed
+                await self.server.network_completion
+            else:
+                id_to_image[dataset_id_to_transformed_image_id(id)] = (
+                    lambda id=id: self.images.get_transformed_image_without_cache_eviction(
+                        transform, id
+                    )
+                )
 
         with self.state:
             annotations = self.transformed_detection_annotations.get_annotations(
-                self.detector, id_to_matching_size_img
+                self.detector, id_to_image
             )
         await self.server.network_completion
 
@@ -300,25 +317,26 @@ class TransformsApp(Applet):
                     {"original_detection_to_transformed_detection_score": score},
                 )
 
-        id_to_image = {
-            dataset_id_to_transformed_image_id(id): self.images.get_transformed_image(
-                transform, id
-            )
-            for id in dataset_ids
-        }
-
-        self.on_transform(id_to_image)
-
         self.state.flush()  # needed cuz in async func and modifying state or else UI does not update
+        # sortable score value may have changed which may have changed images that are in view
+        self.server.controller.check_images_in_view()
+
+        self.on_transform(id_to_image)  # inform embeddings app
+        self.state.flush()
 
     def compute_predictions_original_images(self, dataset_ids):
         if not self.state.predictions_original_images_enabled:
             return
 
-        image_id_to_image = {
-            dataset_id_to_image_id(id): self.images.get_image_without_cache_eviction(id)
-            for id in dataset_ids
-        }
+        image_id_to_image = LazyDict(
+            {
+                dataset_id_to_image_id(
+                    id
+                ): lambda id=id: self.images.get_image_without_cache_eviction(id)
+                for id in dataset_ids
+            }
+        )
+
         self.predictions_original_images = self.original_detection_annotations.get_annotations(
             self.detector, image_id_to_image
         )
@@ -336,24 +354,42 @@ class TransformsApp(Applet):
                 self.state, dataset_id, {"original_ground_to_original_detection_score": score}
             )
 
-    async def _update_images(self, dataset_ids):
-        # load images on state for ImageList
-        for id in dataset_ids:
+    async def _update_images(self, dataset_ids, visible=False):
+        if visible:
+            # load images on state for ImageList
             with self.state:
-                self.images.get_stateful_image(id)
+                for id in dataset_ids:
+                    self.images.get_stateful_image(id)
+                self.ground_truth_annotations.get_annotations(dataset_ids)
             await self.server.network_completion
 
-        with self.state:
-            self.ground_truth_annotations.get_annotations(dataset_ids)
-        await self.server.network_completion
-
+        # always push to state because compute_predictions_original_images updates score metadata
         with self.state:
             self.compute_predictions_original_images(dataset_ids)
         await self.server.network_completion
+        # sortable score value may have changed which may have changed images that are in view
+        self.server.controller.check_images_in_view()
+
+        await self.update_transformed_images(dataset_ids, visible=visible)
+
+    async def _chunk_update_images(self, dataset_ids, visible=False):
+        ids = list(dataset_ids)
+
+        for i in range(0, len(ids), UPDATE_IMAGES_CHUNK_SIZE):
+            chunk = ids[i : i + UPDATE_IMAGES_CHUNK_SIZE]
+            await self._update_images(chunk, visible=visible)
+
+    async def _update_all_images(self, visible_images):
+        with self.state:
+            self.state.updating_images = True
+
+        await self._chunk_update_images(visible_images, visible=True)
+
+        other_images = set(self.state.user_selected_ids) - set(visible_images)
+        await self._chunk_update_images(other_images, visible=False)
 
         with self.state:
-            await self.update_transformed_images(dataset_ids)
-        await self.server.network_completion
+            self.state.updating_images = False
 
     def _cancel_update_images(self, **kwargs):
         if hasattr(self, "_update_task"):
@@ -361,10 +397,9 @@ class TransformsApp(Applet):
 
     def _start_update_images(self, **kwargs):
         self._cancel_update_images()
-        self._update_task = asynchronous.create_task(self._update_images(self.visible_dataset_ids))
-
-    def _updating_images(self):
-        return hasattr(self, "_update_task") and not self._update_task.done()
+        self._update_task = asynchronous.create_task(
+            self._update_all_images(self.visible_dataset_ids)
+        )
 
     def on_scroll(self, visible_ids):
         self.visible_dataset_ids = visible_ids

--- a/src/nrtk_explorer/app/transforms.py
+++ b/src/nrtk_explorer/app/transforms.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, Callable
-from collections.abc import Mapping
+from collections.abc import MutableMapping
 
 from trame.ui.quasar import QLayout
 from trame.widgets import quasar
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class LazyDict(Mapping):
+class LazyDict(MutableMapping):
     """If function provided for value, run function when value is accessed"""
 
     def __init__(self, *args, **kw):
@@ -62,6 +62,9 @@ class LazyDict(Mapping):
 
     def __setitem__(self, key, value):
         self._raw_dict[key] = value
+
+    def __delitem__(self, key):
+        del self._raw_dict[key]
 
     def __iter__(self):
         return iter(self._raw_dict)

--- a/src/nrtk_explorer/app/ui/image_list.css
+++ b/src/nrtk_explorer/app/ui/image_list.css
@@ -8,4 +8,12 @@
   thead tr:first-child th {
     top: 0;
   }
+
+  /* this is when the loading indicator appears */
+  tr:last-child.q-table__progress th {
+    /* height of all previous header rows */
+    top: 48px;
+    position: sticky;
+    z-index: 1;
+  }
 }

--- a/src/nrtk_explorer/library/multiprocess_predictor.py
+++ b/src/nrtk_explorer/library/multiprocess_predictor.py
@@ -1,0 +1,141 @@
+import multiprocessing
+import signal
+import threading
+import logging
+import queue
+import uuid
+from .object_detector import ObjectDetector
+
+
+def _child_worker(request_queue, result_queue, model_name, force_cpu):
+    logger = logging.getLogger(__name__)
+    detector = ObjectDetector(model_name=model_name, force_cpu=force_cpu)
+
+    while True:
+        try:
+            msg = request_queue.get()
+        except (EOFError, KeyboardInterrupt):
+            logger.debug("Worker: Exiting on interrupt or queue EOF.")
+            break
+        if msg is None:  # Exit signal
+            logger.debug("Worker: Received EXIT command. Shutting down.")
+            break
+
+        command = msg["command"]
+        req_id = msg["req_id"]
+        payload = msg.get("payload", {})
+        logger.debug(f"Worker: Received {command} with ID {req_id}")
+
+        if command == "SET_MODEL":
+            try:
+                detector = ObjectDetector(
+                    model_name=payload["model_name"],
+                    force_cpu=payload["force_cpu"],
+                )
+                result_queue.put((req_id, {"status": "OK"}))
+            except Exception as e:
+                logger.exception("Failed to set model.")
+                result_queue.put((req_id, {"status": "ERROR", "message": str(e)}))
+        elif command == "INFER":
+            try:
+                predictions = detector.eval(payload["images"])
+                result_queue.put((req_id, {"status": "OK", "result": predictions}))
+            except Exception as e:
+                logger.exception("Inference failed.")
+                result_queue.put((req_id, {"status": "ERROR", "message": str(e)}))
+        elif command == "RESET":
+            try:
+                detector.reset()
+                result_queue.put((req_id, {"status": "OK"}))
+            except Exception as e:
+                logger.exception("Reset failed.")
+                result_queue.put((req_id, {"status": "ERROR", "message": str(e)}))
+
+    logger.debug("Worker: shutting down.")
+
+
+class MultiprocessPredictor:
+    def __init__(self, model_name="facebook/detr-resnet-50", force_cpu=False):
+        self._lock = threading.Lock()
+        self.model_name = model_name
+        self.force_cpu = force_cpu
+        self._proc = None
+        self._request_queue = None
+        self._result_queue = None
+        self._start_process()
+
+        def handle_shutdown(signum, frame):
+            self.shutdown()
+
+        signal.signal(signal.SIGINT, handle_shutdown)
+
+    def _start_process(self):
+        with self._lock:
+            if self._proc is not None and self._proc.is_alive():
+                self.shutdown()
+            multiprocessing.set_start_method("spawn", force=True)
+            self._request_queue = multiprocessing.Queue()
+            self._result_queue = multiprocessing.Queue()
+            self._proc = multiprocessing.Process(
+                target=_child_worker,
+                args=(
+                    self._request_queue,
+                    self._result_queue,
+                    self.model_name,
+                    self.force_cpu,
+                ),
+                daemon=True,
+            )
+            self._proc.start()
+
+    def set_model(self, model_name, force_cpu=False):
+        with self._lock:
+            self.model_name = model_name
+            self.force_cpu = force_cpu
+            req_id = str(uuid.uuid4())
+            self._request_queue.put(
+                {
+                    "command": "SET_MODEL",
+                    "req_id": req_id,
+                    "payload": {
+                        "model_name": self.model_name,
+                        "force_cpu": self.force_cpu,
+                    },
+                }
+            )
+            return self._wait_for_response(req_id)
+
+    def infer(self, images):
+        if not images:
+            return {}
+        with self._lock:
+            req_id = str(uuid.uuid4())
+            new_req = {"command": "INFER", "req_id": req_id, "payload": {"images": images}}
+            self._request_queue.put(new_req)
+
+        resp = self._wait_for_response(req_id)
+        return resp.get("result")
+
+    def reset(self):
+        with self._lock:
+            req_id = str(uuid.uuid4())
+            self._request_queue.put({"command": "RESET", "req_id": req_id})
+            return self._wait_for_response(req_id)
+
+    def _wait_for_response(self, req_id):
+        while True:
+            try:
+                r_id, data = self._result_queue.get(timeout=40)
+            except queue.Empty:
+                raise TimeoutError("No response from worker.")
+            if r_id == req_id:
+                return data
+
+    def shutdown(self):
+        with self._lock:
+            try:
+                self._request_queue.put(None)
+            except Exception:
+                logging.warning("Could not send exit message to worker.")
+            if self._proc:
+                self._proc.join()

--- a/src/nrtk_explorer/library/object_detector.py
+++ b/src/nrtk_explorer/library/object_detector.py
@@ -50,12 +50,9 @@ class ObjectDetector:
     @pipeline.setter
     def pipeline(self, model_name: str):
         """Set the pipeline for object detection using Hugging Face's transformers library"""
-        if self.task is None:
-            self._pipeline = transformers.pipeline(model=model_name, device=self.device)
-        else:
-            self._pipeline = transformers.pipeline(
-                model=model_name, device=self.device, task=self.task
-            )
+        self._pipeline = transformers.pipeline(
+            model=model_name, device=self.device, task=self.task, use_fast=True
+        )
         # Do not display warnings
         transformers.utils.logging.set_verbosity_error()
 
@@ -109,7 +106,7 @@ class ObjectDetector:
                     self.batch_size = self.batch_size // 2
                     self.batch_size = self.batch_size
                     print(
-                        f"OOM (Pytorch exception {e}) due to batch_size={previous_batch_size}, setting batch_size={self.batch_size}"
+                        f"Caught out of memory exception:\n{e}\nWas batch_size={previous_batch_size}, setting batch_size={self.batch_size}"
                     )
                 else:
                     raise

--- a/src/nrtk_explorer/library/object_detector.py
+++ b/src/nrtk_explorer/library/object_detector.py
@@ -68,6 +68,8 @@ class ObjectDetector:
         batch_size: int = 0,  # 0 means use last successful batch size
     ) -> ImageIdToAnnotations:
         """Compute object recognition. Returns Annotations grouped by input image paths."""
+        if len(images) == 0:
+            return {}  # optimization
 
         images_with_ids = [ImageWithId(id, img) for id, img in images.items()]
 

--- a/src/nrtk_explorer/library/predictor.py
+++ b/src/nrtk_explorer/library/predictor.py
@@ -17,8 +17,7 @@ class ImageWithId(NamedTuple):
 STARTING_BATCH_SIZE = 32
 
 
-class ObjectDetector:
-    """Object detection using Hugging Face's transformers library"""
+class Predictor:
 
     def __init__(
         self,
@@ -106,7 +105,7 @@ class ObjectDetector:
                     self.batch_size = self.batch_size // 2
                     self.batch_size = self.batch_size
                     print(
-                        f"Caught out of memory exception:\n{e}\nWas batch_size={previous_batch_size}, setting batch_size={self.batch_size}"
+                        f"Changing pipeline batch_size from {previous_batch_size} to {self.batch_size} because caught out of memory exception:\n{e}"
                     )
                 else:
                     raise

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,15 +1,15 @@
 import pytest
-from nrtk_explorer.library import object_detector
+from nrtk_explorer.library.predictor import Predictor
+from nrtk_explorer.library.multiprocess_predictor import MultiprocessPredictor
 from nrtk_explorer.library.scoring import compute_score
 from nrtk_explorer.library.dataset import get_dataset
 from utils import get_images, DATASET
-from nrtk_explorer.library.multiprocess_predictor import MultiprocessPredictor
 
 
-def test_detector_small():
+def test_predictor_small():
     sample = get_images()
-    detector = object_detector.ObjectDetector(model_name="hustvl/yolos-tiny")
-    img = detector.eval(sample)
+    predictor = Predictor(model_name="hustvl/yolos-tiny")
+    img = predictor.eval(sample)
     assert len(img) == len(sample.keys())
 
 
@@ -46,8 +46,8 @@ def test_set_model(predictor):
 def test_scorer():
     ds = get_dataset(DATASET)
     sample = get_images()
-    detector = object_detector.ObjectDetector(model_name="facebook/detr-resnet-50")
-    predictions = detector.eval(sample)
+    predictor = Predictor(model_name="facebook/detr-resnet-50")
+    predictions = predictor.eval(sample)
 
     dataset_annotations = dict()
     for annotation in ds.anns.values():

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -4,6 +4,7 @@ from nrtk_explorer.library.multiprocess_predictor import MultiprocessPredictor
 from nrtk_explorer.library.scoring import compute_score
 from nrtk_explorer.library.dataset import get_dataset
 from utils import get_images, DATASET
+import asyncio
 
 
 def test_predictor_small():
@@ -23,7 +24,7 @@ def predictor():
 def test_detect(predictor):
     """Test the detect method with sample images."""
     images = get_images()
-    results = predictor.infer(images)
+    results = asyncio.run(predictor.infer(images))
     assert len(results) == len(images), "Number of results should match number of images"
     for img_id, preds in results.items():
         assert isinstance(preds, list), f"Predictions for {img_id} should be a list"
@@ -33,7 +34,7 @@ def test_set_model(predictor):
     """Test setting a new model and performing detection."""
     predictor.set_model(model_name="hustvl/yolos-tiny")
     images = get_images()
-    results = predictor.infer(images)
+    results = asyncio.run(predictor.infer(images))
     assert len(results) == len(
         images
     ), "Number of results should match number of images after setting new model"


### PR DESCRIPTION
After updating the images visible in the image list, all other selected images are updated and their scores computed.
After images are scored, the table sort may have changed the images that are visible, so ImageList is asked to send visible image IDs again, which may trigger a new `_update_all_images` if the set of images in view has changed.

`transformers.pipeline` is not async, so we run that in subprocess via `multiprocess_predictor.py`


